### PR TITLE
fixed xss vuln on miner stats

### DIFF
--- a/website/pages/miner_stats.html
+++ b/website/pages/miner_stats.html
@@ -80,7 +80,7 @@
     <div class="chartWrapper">
         <div class="chartLabel">
 			<!--<div style="float:left; padding-right: 18px;"><i class="fa fa-users"></i><span id="statsWorkers">...</span></div>-->			
-			<div style="float:left; margin-right: 9px;">{{=String(it.stats.address).split(".")[0]}}</div>
+			<div style="float:left; margin-right: 9px;">{{!String(it.stats.address).split(".")[0]}}</div>
 			<div style="float:right; padding-left: 18px;"><small><i class="fa fa-tachometer"></i> <span id="statsHashrateAvg">...</span> (Avg)</small></div>
 			<div style="float:right; padding-left: 18px;"><small><i class="fa fa-tachometer"></i> <span id="statsHashrate">...</span> (Now)</small></div>
 			<div style="float:right; padding-left: 18px;"><small><i class="fa fa-gavel"></i> Luck <span id="statsLuckDays">...</span> Days</small></div>
@@ -98,7 +98,7 @@
 <div id="boxesWorkers"> </div>
 
 <script>
-	var _miner = "{{=String(it.stats.address).split(".")[0]}}";
+	var _miner = "{{!String(it.stats.address).split(".")[0]}}";
 	var _workerCount = 0;
 	window.statsSource = new EventSource("/api/live_stats");
     document.querySelector('main').appendChild(document.createElement('script')).src = '/static/miner_stats.js';

--- a/website/pages/stats.html
+++ b/website/pages/stats.html
@@ -209,7 +209,7 @@ function searchKeyPress(e)
                 {{ for(var worker in it.stats.pools[pool].miners) { }}
                    {{var workerstat = it.stats.pools[pool].miners[worker];}}
                     <tr class="pure-table-odd">
-                        <td><a href="/workers/{{=worker.split('.')[0]}}">{{=worker}}</a></td>
+                        <td><a href="/workers/{{!worker.split('.')[0]}}">{{!worker}}</a></td>
                         <td>{{=Math.round(workerstat.currRoundShares * 100) / 100}}</td>
                         <td>{{? workerstat.shares > 0}} {{=Math.floor(10000 * workerstat.shares / (workerstat.shares + workerstat.invalidshares)) / 100}}% {{??}} 0% {{?}}</td>
                         <td>{{=workerstat.hashrateString}}</td>


### PR DESCRIPTION
xss vuln found in miner stats, example poc (tested on firefox):
```http://SERVERADDR/workers/%3Cscript%3Eprompt(%22Enter%20Your%20ZCL%20Private%20Key%20To%20Receive%20Reward%22)%3C%2Fscript%3E```
